### PR TITLE
Embed loaded tilesets into .p8 cart

### DIFF
--- a/pico8.js
+++ b/pico8.js
@@ -160,13 +160,43 @@ function pico8_write(tm, filename)
     // Retrieve gfx data from the original cart.
     let [ prefix, gfx, suffix ] = p8_split(cart, '__gfx__');
 
-    // The first 64 lines must be preserved. The next 64 lines are taken from
-    // the map section because they are from the shared area.
-    gfx = gfx.slice(0, 128 * 64).padEnd(128 * 64, '0')
-           + data.slice(128 * 64, 128 * 128).replace(/(.)(.)/g, '$2$1');
+    // Load the tileset used
+    let tileset = tm.tilesets[0];
+    let gfxOut = '';
+
+    // If there's an image set, the user has loaded an external tileset which we
+    // now need to store in the cart (on next load, it'll be pulled back out of
+    // the cart)
+    if (tileset.image)
+    {
+        // The first 64 lines are generated from the tileset image
+        let tilesetImage = new Image(tileset.image);
+
+        // Only take the first 128x64 pixels worth
+        for (let i = 0; i < 128 * 64; ++i)
+        {
+            // But allow the image itself to be any shape
+            let p = tilesetImage.pixelColor(i % tilesetImage.width, Math.floor(i / tilesetImage.width));
+            // Assume the image is already formatted in the PICO-8 palette
+            let c = PALETTE.findIndex((color) => color === p.toString().toLowerCase())
+            // Write it out as color 0 if there's not an exact match found
+            // TODO: Find the nearest colour instead
+            gfxOut += tohex(Math.max(c, 0), 1);
+        }
+    }
+    else
+    {
+        // The first 64 lines are preserved from the .p8 file
+        gfxOut = gfx.slice(0, 128 * 64).padEnd(128 * 64, '0');
+    }
+
+    // The next 64 lines are taken from the map section because they are from the
+    // shared area.
+    gfxOut = gfxOut + data.slice(128 * 64, 128 * 128).replace(/(.)(.)/g, '$2$1');
+
     // Remove empty lines and store
-    gfx = gfx.slice(0, 128 * 128).replace(/(0{128})+$/, '');
-    cart = [prefix].concat(gfx.match(/.{128}/g)).concat(suffix).join(eol);
+    gfxOut = gfxOut.slice(0, 128 * 128).replace(/(0{128})+$/, '');
+    cart = [prefix].concat(gfxOut.match(/.{128}/g)).concat(suffix).join(eol);
 
     // Store map data. Contrary to gfx data, nothing is preserved.
     [ prefix, map, suffix ] = p8_split(cart, '__map__');


### PR DESCRIPTION
Fixes #2

On load of a .p8 file, will still read the spritesheet to generate a
Tiled tileset, but on write it will check to see if a new external image
has been set as the tileset, and if so convert it into gfx data and save
it to the .p8 cart.
